### PR TITLE
Force navigation bar background to match status bar in dark theme

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -19,4 +19,5 @@
   <color name="colorPrimary">@color/colorPrimaryAlt</color>
   <color name="colorPrimaryDark">@color/colorPrimaryDarkAlt</color>
   <color name="headerBackground">#424242</color>
+  <color name="navbarBackground">#000000</color>
 </resources>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -19,5 +19,4 @@
   <color name="colorPrimary">@color/colorPrimaryAlt</color>
   <color name="colorPrimaryDark">@color/colorPrimaryDarkAlt</color>
   <color name="headerBackground">#424242</color>
-  <color name="navbarBackground">#000000</color>
 </resources>

--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -18,7 +18,7 @@
 
   <style name="CatchUp" parent="Base">
     <item name="android:windowLightStatusBar" tools:ignore="NewApi">false</item>
-    <item name="android:navigationBarColor">@color/navbarBackground</item>
+    <item name="android:navigationBarColor">@color/colorPrimaryDark</item>
   </style>
 
   <style name="CatchUp.TabLayout.Inverted" parent="Widget.Design.TabLayout">

--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -18,6 +18,7 @@
 
   <style name="CatchUp" parent="Base">
     <item name="android:windowLightStatusBar" tools:ignore="NewApi">false</item>
+    <item name="android:navigationBarColor">@color/navbarBackground</item>
   </style>
 
   <style name="CatchUp.TabLayout.Inverted" parent="Widget.Design.TabLayout">


### PR DESCRIPTION
Hi,

Thank you so much for this app, I've been using it for a few days now ! I really enjoy the dark theme, but my shiny new Galaxy S8 has a default white navigation bar which makes this theme... weird 😄 

![screenshot_20171026-210602](https://user-images.githubusercontent.com/39268/32078516-6fd6b298-baa7-11e7-83f1-ec3827ae396e.png)

I fixed this by setting the `android:navigationBarColor` to black for the `night` theme. It works great, but there may be more elegant ways of doing it. 

It should have no effect on phones with a black navigation bar as default (Pixel, ...). Note that on those phones, you have the opposite "problem" of having a dark navigation bar for the "light" theme, but it does feel less of a problem as it is the standard behavior.

ps : I'm not sure what's the correct way of contributing on such issues. Submitting the PR felt the right way, but should I create an associated issue ?