### PR TITLE
Use existing string resource for settings screen toolbar title

### DIFF
--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -31,7 +31,7 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?actionBarSize"
-        app:title="Settings"
+        app:title="@string/title_activity_settings"
         />
 
   </android.support.design.widget.AppBarLayout>


### PR DESCRIPTION
... instead of hardcoded "Settings" string.

I noticed this while working on the french translation (PR #75) 😃 