### PR TITLE
Mark API and CatchUpItem v2

### DIFF
--- a/app/schemas/io.sweers.catchup.data.CatchUpDatabase/2.json
+++ b/app/schemas/io.sweers.catchup.data.CatchUpDatabase/2.json
@@ -1,0 +1,223 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "f6d0e42c89b965f14c1253124276e361",
+    "entities": [
+      {
+        "tableName": "pages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `type` TEXT NOT NULL, `expiration` INTEGER NOT NULL, `page` TEXT NOT NULL, `sessionId` INTEGER NOT NULL, `items` TEXT NOT NULL, `nextPageToken` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiration",
+            "columnName": "expiration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "items",
+            "columnName": "items",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextPageToken",
+            "columnName": "nextPageToken",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `title` TEXT NOT NULL, `timestamp` INTEGER, `score` TEXT, `tag` TEXT, `author` TEXT, `source` TEXT, `itemClickUrl` TEXT, `value` TEXT, `type` TEXT, `url` TEXT, `animatable` INTEGER, `bestSize` TEXT, `text` TEXT, `textPrefix` TEXT, `icon` INTEGER, `clickUrl` TEXT, `iconTintColor` INTEGER, `formatTextAsCount` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "itemClickUrl",
+            "columnName": "itemClickUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "summarizationInfo.value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "summarizationInfo.type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageInfo.url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageInfo.animatable",
+            "columnName": "animatable",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageInfo.bestSize",
+            "columnName": "bestSize",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mark.text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mark.textPrefix",
+            "columnName": "textPrefix",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mark.icon",
+            "columnName": "icon",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mark.clickUrl",
+            "columnName": "clickUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mark.iconTintColor",
+            "columnName": "iconTintColor",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mark.formatTextAsCount",
+            "columnName": "formatTextAsCount",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "smmryEntries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`url` TEXT NOT NULL, `json` TEXT NOT NULL, PRIMARY KEY(`url`))",
+        "fields": [
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "json",
+            "columnName": "json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "url"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"f6d0e42c89b965f14c1253124276e361\")"
+    ]
+  }
+}

--- a/app/src/main/kotlin/io/sweers/catchup/data/CatchUpDatabase.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/data/CatchUpDatabase.kt
@@ -34,7 +34,7 @@ import org.threeten.bp.Instant
     CatchUpItem::class,
     SmmryStorageEntry::class
     ],
-    version = 1)
+    version = 2)
 @TypeConverters(CatchUpConverters::class)
 abstract class CatchUpDatabase : RoomDatabase() {
 

--- a/app/src/main/kotlin/io/sweers/catchup/ui/about/ChangelogController.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/about/ChangelogController.kt
@@ -164,7 +164,7 @@ class ChangelogController : ButterKnifeController(), Scrollable {
         timestamp(item.timestamp)
         source(item.sha)
         author(null)
-        hideComments()
+        hideMark()
         itemClicks()
             .flatMapCompletable {
               return@flatMapCompletable linkManager.openUrl(

--- a/app/src/main/kotlin/io/sweers/catchup/ui/about/LicensesController.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/about/LicensesController.kt
@@ -357,7 +357,7 @@ class LicensesController : ButterKnifeController(), Scrollable {
           author(item.license)
           source(null)
           tag(null)
-          hideComments()
+          hideMark()
           itemClicks()
               .flatMapCompletable {
                 // Search up to the first sticky header position

--- a/app/src/main/kotlin/io/sweers/catchup/ui/controllers/service/ImageAdapter.kt
+++ b/app/src/main/kotlin/io/sweers/catchup/ui/controllers/service/ImageAdapter.kt
@@ -233,7 +233,7 @@ internal class ImageAdapter(private val context: Context,
     override fun bind(item: CatchUpItem,
         linkHandler: LinkHandler,
         itemClickHandler: ((String) -> Any)?,
-        commentClickHandler: ((String) -> Any)?) {
+        markClickHandler: ((String) -> Any)?) {
       backingImageItem?.let { imageItem ->
         item.itemClickUrl?.let {
           itemClickHandler?.invoke(it)

--- a/app/src/main/res/layout/list_item_general.xml
+++ b/app/src/main/res/layout/list_item_general.xml
@@ -135,7 +135,7 @@
       android:fontFamily="@font/nunito"
       app:fontFamily="@font/nunito"
       app:layout_constraintBottom_toTopOf="@+id/title"
-      app:layout_constraintEnd_toStartOf="@+id/comments"
+      app:layout_constraintEnd_toStartOf="@+id/mark"
       app:layout_constraintStart_toEndOf="@+id/tag_divider"
       app:layout_constraintTop_toTopOf="@+id/guideline_top"
       app:layout_constraintVertical_bias="0"
@@ -156,7 +156,7 @@
       app:layout_constraintBottom_toTopOf="@+id/source"
       app:layout_constraintLeft_toLeftOf="@+id/guideline"
       app:layout_constraintLeft_toRightOf="@+id/guideline"
-      app:layout_constraintRight_toLeftOf="@+id/comments"
+      app:layout_constraintRight_toLeftOf="@+id/mark"
       app:layout_constraintTop_toBottomOf="@+id/timestamp"
       app:layout_goneMarginTop="0dp"
       tools:text="Show HN: Into.js Hints"
@@ -204,7 +204,7 @@
       android:fontFamily="@font/nunito"
       app:fontFamily="@font/nunito"
       app:layout_constraintBottom_toBottomOf="@+id/guideline_bottom"
-      app:layout_constraintEnd_toStartOf="@+id/comments"
+      app:layout_constraintEnd_toStartOf="@+id/mark"
       app:layout_constraintStart_toEndOf="@+id/author_divider"
       app:layout_constraintTop_toBottomOf="@+id/title"
       tools:text="medium.com"
@@ -212,7 +212,7 @@
       />
 
   <io.sweers.catchup.ui.widget.BaselineGridTextView
-      android:id="@+id/comments"
+      android:id="@+id/mark"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_gravity="center"

--- a/service-api/src/main/kotlin/io/sweers/catchup/service/api/BindableCatchUpItemViewHolder.kt
+++ b/service-api/src/main/kotlin/io/sweers/catchup/service/api/BindableCatchUpItemViewHolder.kt
@@ -30,7 +30,7 @@ interface BindableCatchUpItemViewHolder : ScopeProvider {
   fun bind(item: CatchUpItem,
       linkHandler: LinkHandler,
       itemClickHandler: ((String) -> Any)? = null,
-      commentClickHandler: ((String) -> Any)? = null)
+      markClickHandler: ((String) -> Any)? = null)
 
   fun itemClicks(): Observable<Unit> {
     TODO("itemClicks not implemented!")

--- a/service-api/src/main/kotlin/io/sweers/catchup/service/api/CatchUpItem.kt
+++ b/service-api/src/main/kotlin/io/sweers/catchup/service/api/CatchUpItem.kt
@@ -27,7 +27,7 @@ import org.threeten.bp.Instant
 data class CatchUpItem(
     @PrimaryKey val id: Long,
     val title: String,
-    val timestamp: Instant,
+    val timestamp: Instant?,
     val score: Pair<String, Int>? = null,
     val tag: String? = null,
     val author: String? = null,

--- a/service-api/src/main/kotlin/io/sweers/catchup/service/api/CatchUpItem.kt
+++ b/service-api/src/main/kotlin/io/sweers/catchup/service/api/CatchUpItem.kt
@@ -32,12 +32,10 @@ data class CatchUpItem(
     val tag: String? = null,
     val author: String? = null,
     val source: String? = null,
-    val commentCount: Int = 0,
-    val hideComments: Boolean = false,
     val itemClickUrl: String? = null,
-    val itemCommentClickUrl: String? = null,
     @Embedded val summarizationInfo: SummarizationInfo? = null,
-    @Embedded val imageInfo: ImageInfo? = null
+    @Embedded val imageInfo: ImageInfo? = null,
+    @Embedded val mark: Mark? = null
 ) : DisplayableItem {
 
   override fun stableId() = id

--- a/service-api/src/main/kotlin/io/sweers/catchup/service/api/ImageInfo.kt
+++ b/service-api/src/main/kotlin/io/sweers/catchup/service/api/ImageInfo.kt
@@ -17,7 +17,7 @@
 package io.sweers.catchup.service.api
 
 // Gross vars/constructors because of https://issuetracker.google.com/issues/67181813
-class ImageInfo(
+data class ImageInfo(
     var url: String,
     var animatable: Boolean,
     var bestSize: Pair<Int, Int>?

--- a/service-api/src/main/kotlin/io/sweers/catchup/service/api/Mark.kt
+++ b/service-api/src/main/kotlin/io/sweers/catchup/service/api/Mark.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2018 Zac Sweers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sweers.catchup.service.api
+
+import androidx.annotation.ColorInt
+import androidx.annotation.DrawableRes
+
+/**
+ * A mark is a mark on the side of a catchup text item that can indicate some extra information,
+ * such as a comment or delta or something that makes the reason for this item being here relevant
+ * or important.
+ *
+ * Gross vars/constructors because of https://issuetracker.google.com/issues/67181813
+ */
+data class Mark(
+    var text: String? = null,
+    var textPrefix: String? = null,
+    /**
+     * By default, the icon used is a comment icon if this is null
+     */
+    @DrawableRes var icon: Int? = null,
+    var clickUrl: String? = null,
+    @ColorInt var iconTintColor: Int? = null,
+    var formatTextAsCount: Boolean = false
+) {
+  constructor() : this(null, null, null, null, null, false)
+
+  companion object {
+    fun createCommentMark(count: Int, clickUrl: String? = null): Mark {
+      return Mark(text = count.toString(),
+          clickUrl = clickUrl,
+          formatTextAsCount = true
+      )
+    }
+  }
+}

--- a/service-api/src/main/kotlin/io/sweers/catchup/service/api/SummarizationInfo.kt
+++ b/service-api/src/main/kotlin/io/sweers/catchup/service/api/SummarizationInfo.kt
@@ -20,7 +20,7 @@ import io.sweers.catchup.service.api.SummarizationType.TEXT
 import io.sweers.catchup.service.api.SummarizationType.URL
 import okhttp3.HttpUrl
 
-class SummarizationInfo(
+data class SummarizationInfo(
     val value: String,
     val type: SummarizationType
 ) {

--- a/service-api/src/main/kotlin/io/sweers/catchup/service/api/TextService.kt
+++ b/service-api/src/main/kotlin/io/sweers/catchup/service/api/TextService.kt
@@ -38,7 +38,7 @@ interface TextService : Service {
                 .subscribe()
           }
         },
-        commentClickHandler = item.itemCommentClickUrl?.let {
+        markClickHandler = item.mark?.clickUrl?.let {
           { url: String ->
             holder.itemCommentClicks()
                 .map { createUrlMeta(url, context) }

--- a/services/designernews/src/main/kotlin/io/sweers/catchup/service/designernews/DesignerNewsService.kt
+++ b/services/designernews/src/main/kotlin/io/sweers/catchup/service/designernews/DesignerNewsService.kt
@@ -29,6 +29,7 @@ import io.sweers.catchup.service.api.CatchUpItem
 import io.sweers.catchup.service.api.DataRequest
 import io.sweers.catchup.service.api.DataResult
 import io.sweers.catchup.service.api.LinkHandler
+import io.sweers.catchup.service.api.Mark.Companion.createCommentMark
 import io.sweers.catchup.service.api.Service
 import io.sweers.catchup.service.api.ServiceKey
 import io.sweers.catchup.service.api.ServiceMeta
@@ -72,12 +73,13 @@ internal class DesignerNewsService @Inject constructor(
                 score = "▲" to voteCount,
                 timestamp = createdAt,
                 source = hostname,
-                commentCount = commentCount,
                 tag = badge,
                 itemClickUrl = url,
-                itemCommentClickUrl = href
-                    .replace("api.", "www.")
-                    .replace("api/v2/", "")
+                mark = createCommentMark(
+                    count = commentCount,
+                    clickUrl = href.replace("api.", "www.")
+                        .replace("api/v2/", "")
+                )
             )
           }
         }

--- a/services/dribbble/src/main/kotlin/io/sweers/catchup/service/dribbble/DribbbleService.kt
+++ b/services/dribbble/src/main/kotlin/io/sweers/catchup/service/dribbble/DribbbleService.kt
@@ -28,6 +28,7 @@ import io.sweers.catchup.service.api.DataRequest
 import io.sweers.catchup.service.api.DataResult
 import io.sweers.catchup.service.api.ImageInfo
 import io.sweers.catchup.service.api.LinkHandler
+import io.sweers.catchup.service.api.Mark.Companion.createCommentMark
 import io.sweers.catchup.service.api.Service
 import io.sweers.catchup.service.api.ServiceKey
 import io.sweers.catchup.service.api.ServiceMeta
@@ -66,14 +67,14 @@ internal class DribbbleService @Inject constructor(
               timestamp = it.createdAt,
               author = "/u/" + it.user.name,
               source = null,
-              commentCount = it.commentsCount.toInt(),
               tag = null,
               itemClickUrl = it.htmlUrl,
               imageInfo = ImageInfo(
                   it.images.best(),
                   it.animated,
                   it.images.bestSize()
-              )
+              ),
+              mark = createCommentMark(count = it.commentsCount.toInt())
           )
         }
         .toList()

--- a/services/github/src/main/kotlin/io/sweers/catchup/service/github/GitHubService.kt
+++ b/services/github/src/main/kotlin/io/sweers/catchup/service/github/GitHubService.kt
@@ -34,6 +34,7 @@ import io.sweers.catchup.service.api.CatchUpItem
 import io.sweers.catchup.service.api.DataRequest
 import io.sweers.catchup.service.api.DataResult
 import io.sweers.catchup.service.api.LinkHandler
+import io.sweers.catchup.service.api.Mark
 import io.sweers.catchup.service.api.Service
 import io.sweers.catchup.service.api.ServiceKey
 import io.sweers.catchup.service.api.ServiceMeta
@@ -99,7 +100,6 @@ internal class GitHubService @Inject constructor(
 
                   CatchUpItem(
                       id = id().hashCode().toLong(),
-                      hideComments = true,
                       title = "${name()}$description",
                       score = "★" to stargazers().totalCount().toInt(),
                       timestamp = createdAt(),

--- a/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/HackerNewsService.kt
+++ b/services/hackernews/src/main/kotlin/io/sweers/catchup/service/hackernews/HackerNewsService.kt
@@ -33,6 +33,7 @@ import io.sweers.catchup.service.api.CatchUpItem
 import io.sweers.catchup.service.api.DataRequest
 import io.sweers.catchup.service.api.DataResult
 import io.sweers.catchup.service.api.LinkHandler
+import io.sweers.catchup.service.api.Mark.Companion.createCommentMark
 import io.sweers.catchup.service.api.Service
 import io.sweers.catchup.service.api.ServiceException
 import io.sweers.catchup.service.api.ServiceKey
@@ -115,11 +116,13 @@ internal class HackerNewsService @Inject constructor(
                 timestamp = realTime(),
                 author = by,
                 source = url?.let { HttpUrl.parse(it)!!.host() },
-                commentCount = kids?.size ?: 0,
                 tag = realType()?.tag(nullIfStory = true),
                 itemClickUrl = url,
-                itemCommentClickUrl = "https://news.ycombinator.com/item?id=$id",
-                summarizationInfo = SummarizationInfo.from(url)
+                summarizationInfo = SummarizationInfo.from(url),
+                mark = kids?.size?.let {
+                  createCommentMark(count = it,
+                      clickUrl = "https://news.ycombinator.com/item?id=$id")
+                }
             )
           }
         }

--- a/services/medium/src/main/kotlin/io/sweers/catchup/service/medium/MediumService.kt
+++ b/services/medium/src/main/kotlin/io/sweers/catchup/service/medium/MediumService.kt
@@ -29,6 +29,7 @@ import io.sweers.catchup.service.api.CatchUpItem
 import io.sweers.catchup.service.api.DataRequest
 import io.sweers.catchup.service.api.DataResult
 import io.sweers.catchup.service.api.LinkHandler
+import io.sweers.catchup.service.api.Mark.Companion.createCommentMark
 import io.sweers.catchup.service.api.Service
 import io.sweers.catchup.service.api.ServiceKey
 import io.sweers.catchup.service.api.ServiceMeta
@@ -86,11 +87,13 @@ internal class MediumService @Inject constructor(
                     to post.virtuals.recommends,
                 timestamp = post.createdAt,
                 author = user.name,
-                commentCount = post.virtuals.responsesCreatedCount,
                 tag = collection?.name,
                 itemClickUrl = url,
-                itemCommentClickUrl = constructCommentsUrl(),
-                summarizationInfo = SummarizationInfo.from(url)
+                summarizationInfo = SummarizationInfo.from(url),
+                mark = createCommentMark(
+                    count = post.virtuals.responsesCreatedCount,
+                    clickUrl = constructCommentsUrl()
+                )
             )
           }
         }

--- a/services/producthunt/src/main/kotlin/io/sweers/catchup/service/producthunt/ProductHuntService.kt
+++ b/services/producthunt/src/main/kotlin/io/sweers/catchup/service/producthunt/ProductHuntService.kt
@@ -28,6 +28,7 @@ import io.sweers.catchup.service.api.CatchUpItem
 import io.sweers.catchup.service.api.DataRequest
 import io.sweers.catchup.service.api.DataResult
 import io.sweers.catchup.service.api.LinkHandler
+import io.sweers.catchup.service.api.Mark.Companion.createCommentMark
 import io.sweers.catchup.service.api.Service
 import io.sweers.catchup.service.api.ServiceKey
 import io.sweers.catchup.service.api.ServiceMeta
@@ -71,9 +72,11 @@ internal class ProductHuntService @Inject constructor(
                 timestamp = createdAt,
                 author = user.name,
                 tag = firstTopic,
-                commentCount = commentsCount,
                 itemClickUrl = redirectUrl,
-                itemCommentClickUrl = discussionUrl
+                mark = createCommentMark(
+                    count = commentsCount,
+                    clickUrl = discussionUrl
+                )
             )
           }
         }

--- a/services/reddit/src/main/kotlin/io/sweers/catchup/service/reddit/RedditService.kt
+++ b/services/reddit/src/main/kotlin/io/sweers/catchup/service/reddit/RedditService.kt
@@ -28,6 +28,7 @@ import io.sweers.catchup.service.api.CatchUpItem
 import io.sweers.catchup.service.api.DataRequest
 import io.sweers.catchup.service.api.DataResult
 import io.sweers.catchup.service.api.LinkHandler
+import io.sweers.catchup.service.api.Mark.Companion.createCommentMark
 import io.sweers.catchup.service.api.Service
 import io.sweers.catchup.service.api.ServiceKey
 import io.sweers.catchup.service.api.ServiceMeta
@@ -75,11 +76,13 @@ internal class RedditService @Inject constructor(
                     timestamp = it.createdUtc,
                     author = "/u/" + it.author,
                     source = it.domain ?: "self",
-                    commentCount = it.commentsCount,
                     tag = it.subreddit,
                     itemClickUrl = it.url,
-                    itemCommentClickUrl = "https://reddit.com/comments/${it.id}",
-                    summarizationInfo = SummarizationInfo.from(it.url, it.selftext)
+                    summarizationInfo = SummarizationInfo.from(it.url, it.selftext),
+                    mark = createCommentMark(
+                        count = it.commentsCount,
+                        clickUrl = "https://reddit.com/comments/${it.id}"
+                    )
                 )
               }
           DataResult(data, redditListingRedditResponse.data.after)

--- a/services/slashdot/src/main/kotlin/io/sweers/catchup/service/slashdot/SlashdotService.kt
+++ b/services/slashdot/src/main/kotlin/io/sweers/catchup/service/slashdot/SlashdotService.kt
@@ -29,6 +29,7 @@ import io.sweers.catchup.service.api.CatchUpItem
 import io.sweers.catchup.service.api.DataRequest
 import io.sweers.catchup.service.api.DataResult
 import io.sweers.catchup.service.api.LinkHandler
+import io.sweers.catchup.service.api.Mark.Companion.createCommentMark
 import io.sweers.catchup.service.api.Service
 import io.sweers.catchup.service.api.ServiceKey
 import io.sweers.catchup.service.api.ServiceMeta
@@ -70,11 +71,13 @@ internal class SlashdotService @Inject constructor(
               timestamp = updated,
               author = author.name,
               source = department,
-              commentCount = comments,
               tag = section,
               itemClickUrl = id,
-              itemCommentClickUrl = "$id#comments",
-              summarizationInfo = SummarizationInfo(summary.substringBefore("<p>"), NONE)
+              summarizationInfo = SummarizationInfo(summary.substringBefore("<p>"), NONE),
+              mark = createCommentMark(
+                  count = comments,
+                  clickUrl = "$id#comments"
+              )
           )
         }
         .toList()


### PR DESCRIPTION
`CatchUpItem` has been growing a bit overly-organically and was due for some pruning. This introduces a new `Mark` API to generify what was the `comments` item for any sort of added decorator for items.

This also opportunistically makes some changes:
- `timestamp` is now nullable
- make `ImageInfo` and `SummarizationInfo` data classes (as they should be)